### PR TITLE
added ability to save blog posts to /advocated - fixes issue #21

### DIFF
--- a/lib/slack.js
+++ b/lib/slack.js
@@ -34,6 +34,14 @@ user:
   comments: 'ha ho yes',
   presenter: 'b7b12408c2b7059433eb0e87670038a3' }
   
+{ collection: 'blog',
+  title: 'Guitars are great',
+  dtstart: '2015-04-03',
+  url: 99,
+  tags: [ 'a', 'b', 'c' ],
+  comments: 'ha ho yes',
+  author: 'b7b12408c2b7059433eb0e87670038a3' }
+  
 */
 
 var formatPost = function(obj, callback) {
@@ -50,6 +58,9 @@ var formatPost = function(obj, callback) {
     if (!isNaN(obj.attendees)) {
       str += ' with ' + obj.attendees + ' people.';
     }
+  } else if (obj.collection == "blog") {
+    str += "Hey! *" + obj.user.display_name + "* just `/advocated` with a blog ";
+    str += '*' + obj.title + '* --> ' + obj.url;
   }
   if (str.length >0) {
     post(str, callback); 

--- a/lib/users.js
+++ b/lib/users.js
@@ -8,7 +8,6 @@ var cloudant = require('./db.js'),
 // search for a user by their identifier
 var getByIdentifier = function(authtype, identifier, callback) {
   db.view('find', 'userbyidentifier', { key:[authtype, identifier], limit: 1, include_docs:true}, function(err, data) {
-    console.log("find/userbyidentifier", err, data);
     callback(null, (data.rows)?data.rows[0]:null);
   });
 };

--- a/views/blogged.jade
+++ b/views/blogged.jade
@@ -1,0 +1,64 @@
+doctype html
+html(lang="en")
+head
+  include head.jade
+body.capped-layout
+  header.capped-layout_cap.app-banner
+    span.app-banner_title IBM Cloud Data Services // Dev
+    
+  div.capped-layout_body.bookend-layout
+    nav.bookend-layout_bookend.theme_light.bg_white
+      include nav.jade
+      
+    div.bookend-layout_body.theme_dark
+      //-section.layout_section.theme_light
+        //-h1.type_heading
+          //-mark.type_mark Presented at an Event
+      
+      section.layout_section  
+        h1.type_heading
+          mark.type_mark Published a blog post
+                    
+        form(id="blogged")
+          div.form_standard
+            input(type="hidden",name="collection",value="blog")
+            if doc._id
+             input(type="hidden",name="_id",value="#{doc._id}")
+            if doc._rev
+             input(type="hidden",name="_rev",value="#{doc._rev}")
+      
+            div.form_field
+              label.form_label(for="blogtitle") Title
+              input.input_text.input_wide#blogtitle.form-control(name="title",value="#{doc.title}")
+            
+            div.form_field
+              label.form_label(for="blogdate") Date
+              input.input_text.input_wide#blogdate.form-control(name="dtstart",type="date",placeholder="YYYY-MM-DD",value=(doc.dtstart ? "#{doc.dtstart}" : ""))
+      
+            div.form_field
+              label.form_label(for="blogurl") URL
+              input.input_text.input_wide#blogurl.form-control(name="url",type="url",value="#{doc.url}")
+
+            div.form_field
+              label.form_label(for="blogtags") Tags
+              input.input_text.input_wide#blogtags.form-control(name="tags",type="text",placeholder="e.g. Node,Geo",value=(doc.tags ? "#{doc.tags}" : ""))
+
+            div.form_field
+              label.form_label(for="blogcomments") Comments
+              textarea.input_textarea.input_wide#blogcomments.form-control(name="comments") #{doc.comments}
+       
+            div#error
+            div#message   
+       
+            if doc._id
+             button.button_primary(type="submit") Update
+            else
+             button.button_primary(type="submit") Submit
+
+            script.
+             $( document ).ready(function() {
+               $('#blogged' ).on( "submit", function( event ) {
+                 event.preventDefault();
+                 submitForm($( this ).serialize());
+               });
+             });

--- a/views/nav.jade
+++ b/views/nav.jade
@@ -7,4 +7,6 @@ ul.tree-nav
       li.tree-nav_item
         a.tree-nav_link(href="/presented",role="button") I Presented at an Event
       li.tree-nav_item
+        a.tree-nav_link(href="/blogged",role="button") I published a blog
+      li.tree-nav_item
         a.tree-nav_link(href="/menu",role="button") My Events

--- a/views/nav.jade
+++ b/views/nav.jade
@@ -7,6 +7,6 @@ ul.tree-nav
       li.tree-nav_item
         a.tree-nav_link(href="/presented",role="button") I Presented at an Event
       li.tree-nav_item
-        a.tree-nav_link(href="/blogged",role="button") I published a blog
+        a.tree-nav_link(href="/blogged",role="button") I Published a Blog
       li.tree-nav_item
         a.tree-nav_link(href="/menu",role="button") My Events


### PR DESCRIPTION
Added a new form to allow blog posts to be recorded in /advocated. The user would log in as normal and completed a "I just blogged" form supplying:
- title
- url
- date
- tags
- comments

It is saved with the other data in the same collection in documents like this:

```
{
   "_id": "39e7a45f904ffe701e1fe0bce3006ddd",
   "_rev": "1-0a4b5d352a6cd008a472a10a06096eb1",
   "collection": "blog",
   "title": "Block chain, smart contracts and ethereum",
   "dtstart": "2015-09-09",
   "url": "https://developer.ibm.com/clouddataservices/2016/05/19/block-chain-technology-smart-contracts-and-ethereum/",
   "tags": [
       "a",
       "b",
       "c"
   ],
   "comments": "123",
   "sponsored": false,
   "author": "b7b12408c2b7059433eb0e87670038a3"
}
```
